### PR TITLE
Remove references to Sublimelinter 3

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -1,6 +1,6 @@
 #
 # linter.py
-# Linter for SublimeLinter3, a code checking framework for Sublime Text 3
+# Linter for SublimeLinter, a code checking framework for Sublime Text 3
 #
 # Written by Eric Brown
 # Copyright (c) 2016 Eric Brown


### PR DESCRIPTION
Now that Sublimelinter 4 is out, there is no need to have any
references to Sublimelinter 3.  In fact, it would be better to
remove the version.

Signed-off-by: Eric Brown <browne@vmware.com>