### PR TITLE
Add regex to get error code from bandit output

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class Bandit(PythonLinter):
     version_re = r'^bandit\s(?P<version>\d+.\d+.\d+)'
     version_requirement = '>= 1.3.0'
     regex = (
-        r'^>>\sIssue:\s\[.+\]\s(?P<message>.+)$\r?\n'
+        r'^>>\sIssue:\s\[(?P<code>[B]\d+):.+\]\s(?P<message>.+)$\r?\n'
         r'^.*Severity:\s(?:(?P<error>High)|(?P<warning>(Medium|Low))).*$\r?\n'
         r'^.*Location:.*:(?P<line>\d+)$\r?\n'
     )


### PR DESCRIPTION
This fix modifies the regex to search for the bandit error code.
The bandit error code always begins with 'B' followed by a 3 digit
number.

This will effectively make Sublimelinter-bandit consistent with
other plugins like Sublimelinter-pylint that show an error code.

For example, pylint plugin shows as:
`     1:1    warning       pylint: C0111        Missing module docstring (missing-docstring)`

Whereas the bandit plugin currently shows as:
`    21:1    warning       bandit: Medium       Use of insecure MD2, MD4, or MD5 hash function.`

After this fix is merged, it will display as:
`    21:1    warning       bandit: B303         Use of insecure MD2, MD4, or MD5 hash function.`

Signed-off-by: Eric Brown <browne@vmware.com>