### PR TITLE
Fix the error code to properly display

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -15,3 +15,21 @@ class Bandit(PythonLinter):
         '--tests,': '',
         '--skips,': ''
     }
+
+    def split_match(self, match):
+        """
+        Return the components of the error message.
+
+        We override this to add the error code as part of the message.
+        """
+        match, line, col, error, warning, message, near = super(
+            self.__class__, self).split_match(match)
+
+        if match:
+            code = match.group('code')
+            if error:
+                error = code
+            if warning:
+                warning = code
+
+        return match, line, col, error, warning, message, near


### PR DESCRIPTION
In a previous commit [1], an attempt was made to add the error code
to the resulting message. However, this did not work.

The correct way to get the error code is to override the result
of the error or warning variable.

This patch will now show the message as:
 21:1 warning bandit: B303 Use of insecure MD2, MD4, or MD5 hash function.

instead of:
 21:1 warning bandit: Medium Use of insecure MD2, MD4, or MD5 hash function.

[1] https://github.com/SublimeLinter/SublimeLinter-bandit/pull/3

Signed-off-by: Eric Brown <browne@vmware.com>