### PR TITLE
Update the link to the bandit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SublimeLinter-bandit
 ====================
 
-This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [bandit](https://wiki.openstack.org/wiki/Security/Projects/Bandit).
+This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [bandit](https://bandit.readthedocs.io/).
 It will be used with files that have the "python" syntax.
 
 ## Installation


### PR DESCRIPTION
Recently Bandit was migration from OpenStack to PyCQA of GitHub.
As a result, this linter should no longer be pointing to the legacy
documentation of the OpenStack version of Bandit.

The new documentation for Bandit is found on readthedocs.io

Signed-off-by: Eric Brown <browne@vmware.com>