### PR TITLE
Parse output messages using custom format

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,14 +2,13 @@ from SublimeLinter.lint import PythonLinter, util
 
 
 class Bandit(PythonLinter):
-    cmd = ('bandit', '${args}', '-n', '1', '-f', 'txt', '-')
-    regex = (
-        r'^>>\sIssue:\s\[(?P<code>[B]\d+):.+\]\s(?P<message>.+)$\r?\n'
-        r'^.*Severity:\s(?:(?P<error>High)|(?P<warning>(Medium|Low))).*$\r?\n'
-        r'^.*Location:.*:(?P<line>\d+)$\r?\n'
-    )
-    multiline = True
-    error_stream = util.STREAM_BOTH
+    cmd = ('bandit', '${args}', '-n', '1', '-f', 'custom',
+           '--msg-template', '[{line}][{test_id}][{severity}] {msg}', '-')
+    regex = (r'^\[(?P<line>\d+)\]'
+             r'\[(?P<code>[B]\d+)\]'
+             r'\[(?:(?P<error>HIGH)|(?P<warning>(MEDIUM|LOW)))\]'
+             r'\s(?P<message>.+)$')
+    error_stream = util.STREAM_STDOUT
     defaults = {
         'selector': 'source.python',
         '--tests,': '',


### PR DESCRIPTION
Allows for more control and fixes issues with outputs not recognized by the regex. Previously this linter plugin's status would be displayed as erred all the time because of unrecognized messages, even when no actual errors/warnings were produced, because of logging output to stderr and summary statistics printed after checking the file. Using this custom format the summary output can be prevented, and it simplifies the regex too.

Note: Will require Bandit >=1.5.0 but it's been released for over half a year so it should be fine.