### PR TITLE
Make parser work with newer version of bandit

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,16 +2,12 @@ from SublimeLinter.lint import PythonLinter, util
 
 
 class Bandit(PythonLinter):
-    cmd = ('bandit', '${args}', '-n', '1', '-f', 'txt', '-')
+    cmd = ("bandit", "${args}", "-n", "1", "-f", "txt", "-")
     regex = (
-        r'^>>\sIssue:\s\[(?P<code>[B]\d+):.+\]\s(?P<message>.+)$\r?\n'
-        r'^.*Severity:\s(?:(?P<error>High)|(?P<warning>(Medium|Low))).*$\r?\n'
-        r'^.*Location:.*:(?P<line>\d+)$\r?\n'
+        r"^>>\sIssue:\s\[(?P<code>[B]\d+):.+\]\s(?P<message>.+)$\r?\n"
+        r"^.*Severity:\s(?:(?P<error>High)|(?P<warning>(Medium|Low))).*$\r?\n"
+        r"(.*\r?\n)*^.*Location:.*?:(?P<line>\d+)(:\d+)?$\r?\n"
     )
     multiline = True
     error_stream = util.STREAM_BOTH
-    defaults = {
-        'selector': 'source.python',
-        '--tests,': '',
-        '--skips,': ''
-    }
+    defaults = {"selector": "source.python", "--tests,": "", "--skips,": ""}


### PR DESCRIPTION
The current version of bandit (1.7.9) has additional output between `Severity` and `Location` and looks like this:

```text
Test results:
>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
   Severity: Low   Confidence: High
   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
   More Info: https://bandit.readthedocs.io/en/1.7.9/blacklists/blacklist_imports.html#b404-import-subprocess
   Location: <stdin>:14:0
14	import subprocess  # 1nosec B404

--------------------------------------------------
```

The updated regex works with this kind of output too.